### PR TITLE
AB#39095 Added documentation link buttons

### DIFF
--- a/ToolkitApp/tabs/src/components/sample/DocumentationLinks.jsx
+++ b/ToolkitApp/tabs/src/components/sample/DocumentationLinks.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { GRAPH_EXPLORER_URL, GRAPH_EXPLORER_DOCS_URL, OFFICIAL_RSC_URL} from "./TabConstants";
+import { Button, Flex } from '@fluentui/react-northstar';
+
+const DocumentationLinks = () => {
+    return (
+        <Flex gap="gap.large">
+            <Button content="Go to Graph Explorer" onClick={() => window.open(GRAPH_EXPLORER_URL)} primary />
+            <Button content="Graph Explorer Documentation" onClick={() => window.open(GRAPH_EXPLORER_DOCS_URL)} primary />
+            <Button content="Resource-Specific Consent" onClick={() => window.open(OFFICIAL_RSC_URL)} primary />
+        </Flex>
+    );
+};
+
+export default DocumentationLinks;

--- a/ToolkitApp/tabs/src/components/sample/DocumentationLinks.jsx
+++ b/ToolkitApp/tabs/src/components/sample/DocumentationLinks.jsx
@@ -1,13 +1,16 @@
 import React from "react";
 import { GRAPH_EXPLORER_URL, GRAPH_EXPLORER_DOCS_URL, OFFICIAL_RSC_URL} from "./TabConstants";
 import { Button, Flex } from '@fluentui/react-northstar';
+import { useTranslation } from 'react-i18next';
 
 const DocumentationLinks = () => {
+    const { t } = useTranslation();
+
     return (
         <Flex gap="gap.large">
-            <Button content="Go to Graph Explorer" onClick={() => window.open(GRAPH_EXPLORER_URL)} primary />
-            <Button content="Graph Explorer Documentation" onClick={() => window.open(GRAPH_EXPLORER_DOCS_URL)} primary />
-            <Button content="Resource-Specific Consent" onClick={() => window.open(OFFICIAL_RSC_URL)} primary />
+            <Button content={t("Documentation Links.Go to Graph Explorer")} onClick={() => window.open(GRAPH_EXPLORER_URL)} primary />
+            <Button content={t("Documentation Links.Graph Explorer Documentation")} onClick={() => window.open(GRAPH_EXPLORER_DOCS_URL)} primary />
+            <Button content={t("Documentation Links.Resource-Specific Consent")} onClick={() => window.open(OFFICIAL_RSC_URL)} primary />
         </Flex>
     );
 };

--- a/ToolkitApp/tabs/src/components/sample/MainContent.jsx
+++ b/ToolkitApp/tabs/src/components/sample/MainContent.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { ChevronDownIcon, ChevronEndIcon, Header, Flex } from '@fluentui/react-northstar';
 import { useTranslation } from 'react-i18next';
+import DocumentationLinks from "./DocumentationLinks";
 
 const dummyText =
   "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lacus vestibulum sed arcu non odio. Volutpat diam ut venenatis tellus in metus vulputate. Tellus in hac habitasse platea. Non quam lacus suspendisse faucibus interdum posuere. Est ante in nibh mauris cursus. Duis ut diam quam nulla porttitor massa. Eget felis eget nunc lobortis. Quisque non tellus orci ac auctor augue mauris augue neque. Nibh cras pulvinar mattis nunc sed blandit libero volutpat sed. Cursus risus at ultrices mi tempus imperdiet nulla malesuada. Porta non pulvinar neque laoreet suspendisse interdum consectetur libero id. Tristique nulla aliquet enim tortor at. Volutpat consequat mauris nunc congue. Dignissim diam quis enim lobortis scelerisque fermentum dui faucibus. Phasellus faucibus scelerisque eleifend donec pretium. Sed faucibus turpis in eu mi bibendum neque egestas. Purus in massa tempor nec feugiat nisl pretium fusce. Nunc sed velit dignissim sodales. Et netus et malesuada fames ac turpis egestas maecenas. Convallis tellus id interdum velit laoreet id donec ultrices tincidunt. Dui sapien eget mi proin sed libero enim sed faucibus. Tempus imperdiet nulla malesuada pellentesque. Aliquet eget sit amet tellus cras adipiscing enim. Cursus metus aliquam eleifend mi in. Elementum sagittis vitae et leo duis. Ac turpis egestas sed tempus urna. Ac odio tempor orci dapibus ultrices in iaculis nunc. Habitasse platea dictumst quisque sagittis purus sit. Sed velit dignissim sodales ut eu sem integer vitae justo.";
@@ -83,10 +84,7 @@ const MainContent = () => {
                     <ChevronDownIcon id="documentation-links-chevron"/>
                     <Header id="documentation-links-header" as="h2" content={t("Table of Contents.Documentation Links")} />
                 </Flex>
-                <div>
-                  <p>REMOVE LOREM IPSUM AND PLACE DOCUMENTATION LINKS HERE</p>
-                  <p>{dummyText}</p>
-                </div>
+                <DocumentationLinks />
             </div>
     } else {
         fourthSection = 

--- a/ToolkitApp/tabs/src/translations/en-US.json
+++ b/ToolkitApp/tabs/src/translations/en-US.json
@@ -6,6 +6,12 @@
             "Query Runner": "Query Runner",
             "Resource-Specific Consent": "Resource-Specific Consent",
             "Documentation Links": "Documentation Links"
+        },
+
+        "Documentation Links" : {
+            "Go to Graph Explorer": "Go to Graph Explorer",
+            "Graph Explorer Documentation": "Graph Explorer Documentation",
+            "Resource-Specific Consent": "Resource-Specific Consent"
         }
 
     }

--- a/ToolkitApp/tabs/src/translations/zh-CN.json
+++ b/ToolkitApp/tabs/src/translations/zh-CN.json
@@ -5,6 +5,11 @@
             "Query Runner": "(zh-cn) Query Runner",
             "Resource-Specific Consent": "(zh-cn) Resource-Specific Consent",
             "Documentation Links": "(zh-cn) Documentation Links"
+        },
+        "Documentation Links" : {
+            "Go to Graph Explorer": "(zh-cn) Go to Graph Explorer",
+            "Graph Explorer Documentation": "(zh-cn) Graph Explorer Documentation",
+            "Resource-Specific Consent": "(zh-cn) Resource-Specific Consent"
         }
     }
 }


### PR DESCRIPTION
ADO Board Link: [Task #39095](https://dev.azure.com/microsoftgarage/Intern%20GitHub/_workitems/edit/39095)

## Overview
* We needed buttons linked to Graph Explorer and documentation.

### Demo

https://user-images.githubusercontent.com/46834951/126411526-07b5e869-80c9-419f-bb3e-56c02d965fcf.mp4

### Notes
* Wait for https://github.com/LokiLabs/microsoft-graph-explorer-teams-app/pull/18 to be merged before merging this PR to `interns/dev`

## Testing Instructions
* Pull and run the Teams app.