### PR TITLE
AB#39003 Interns/jerryxihe/39003 rsc list with api after repo cleanup

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -1,11 +1,8 @@
 ## How to update this app's RSC permissions
 
 1. Update the list of RSC permissions in `webApplicationInfo.applicationPermissions` of `teamsApp/manifest.json`.
-1. Copy `webApplicationInfo.applicationPermissions` into the constant `RSC_LIST` in `tabs/src/components/sample/TabConstants.jsx`<sup name="a1">[1](#f1)</sup>.
 1. Zip the `teamsApp` directory.
 1. Go to the Teams app store.
 1. Delete the current Graph Explorer Teams app.
 1. Upload the zipped `teamsApp` via "Upload a custom app" in the bottom left corner.
 1. **TODO**: Deployment and publishing (ADO ticket [#38612](https://dev.azure.com/microsoftgarage/Intern%20GitHub/_backlogs/backlog/GI21%20-%20Graph%20Explorer/Backlog%20items/?workitem=38612))
-
-<b name="f1">1</b>: The reason the `RSC_LIST` constant in `tabs/src/components/sample/TabConstants.jsx` exists is because you cannot import any file outside the `tabs/src` directory into `tabs/src/components/sample/RSCList.jsx`. Thus, we need to create a copy of the RSC permissions list from `teamsApp/manifest.json` and import that as a constant instead. We could move the `teamsApp` directory into `tabs/src`, which would allow us to directly import the RSC permissions list and reduce code duplication, but it might not make sense for `teamsApp` to exist in `tabs/src`. ADO ticket [#38676](https://dev.azure.com/microsoftgarage/Intern%20GitHub/_backlogs/backlog/GI21%20-%20Graph%20Explorer/Backlog%20items/?workitem=38676) covers making this decision. [↩](#a1)

--- a/tabs/src/components/sample/RSCList.jsx
+++ b/tabs/src/components/sample/RSCList.jsx
@@ -1,18 +1,51 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import "./RSCList.css";
-import { RSC_LIST, items, RSC_NAME_DESCRIPTION } from './TabConstants';
-import { Table } from '@fluentui/react-northstar';
+import { CLIENT_APP_ID, items, RSC_NAME_DESCRIPTION, DEVX_API_URL } from './TabConstants';
+import { useTeamsFx } from "../sample/lib/useTeamsFx";
+import { Table } from '@fluentui/react-northstar'
 
 export function RSCList() {
+    const [RSCList, setRSCList] = useState([]);
+    const { context } = useTeamsFx();
+    
+    useEffect(() => {
+        async function getRSCList(context) {
+            if (context?.groupId) {
+                let teamResponse = await fetch(DEVX_API_URL + "/graphproxy/beta/teams/" + context?.groupId + "/permissionGrants").then(response => response.json());
+                const teamRSCs = teamResponse.value;
 
-    const filterPermType = (permType, perm) => perm.includes(permType);
+                if (teamRSCs) {
+                    let filteredRSCs = [];
+                    for (let i = 0; i < teamRSCs.length; i++) {
+                        if (teamRSCs[i].clientAppId === CLIENT_APP_ID) {
+                            filteredRSCs.push(teamRSCs[i].permission);
+                        }
+                    }
+                    setRSCList(filteredRSCs);
+                }
 
-    const RSCRows = RSC_LIST
-        .filter(perm => filterPermType("Group", perm))
+            } else if (context?.chatId) {
+                let chatResponse = await fetch(DEVX_API_URL + "/graphproxy/beta/chats/" + context?.chatId + "/permissionGrants").then(response => response.json());
+                const chatRSCs = chatResponse.value;
+
+                if (chatRSCs) {
+                    let filteredRSCs = [];
+                    for (let i = 0; i < chatRSCs.length; i++) {
+                        if (chatRSCs[i].clientAppId === CLIENT_APP_ID) {
+                            filteredRSCs.push(chatRSCs[i].permission);
+                        }
+                    }
+                    setRSCList(filteredRSCs);
+                }
+            }
+        }
+        getRSCList(context);
+    }, [context]);
+
+    const RSCRows = RSCList
         .map(perm => ({ key: perm, items: [perm, RSC_NAME_DESCRIPTION[perm]], }));
 
     return (
         <Table header={{ items }} rows={RSCRows} aria-label="RSC Table" />
     );
 }
-

--- a/tabs/src/components/sample/TabConstants.jsx
+++ b/tabs/src/components/sample/TabConstants.jsx
@@ -4,33 +4,12 @@ export const RSC_DOCUMENTATION_URL = "https://raw.githubusercontent.com/Microsof
 export const OFFICIAL_RSC_URL = "https://docs.microsoft.com/en-us/microsoftteams/platform/graph-api/rsc/resource-specific-consent#:~:text=Resource-specific%20consent%20%28RSC%29%20is%20a%20Microsoft%20Teams%20and,manage%20specific%20resources%E2%80%94either%20teams%20or%20chats%E2%80%94within%20an%20organization.";
 export const README_HEADER = "---";
 export const MS_GRAPH_DOCS = "(https://docs.microsoft.com/en-us/";
-export const RSC_LIST =
-    [
-        "TeamSettings.Read.Group",
-        "ChannelMessage.Read.Group",
-        "TeamSettings.Edit.Group",
-        "ChannelSettings.ReadWrite.Group",
-        "Channel.Create.Group",
-        "Channel.Delete.Group",
-        "TeamsApp.Read.Group",
-        "TeamsTab.Read.Group",
-        "TeamsTab.Create.Group",
-        "TeamsTab.ReadWrite.Group",
-        "TeamsTab.Delete.Group",
-        "Member.Read.Group",
-        "Owner.Read.Group",
-        "ChatSettings.Read.Chat",
-        "ChatSettings.ReadWrite.Chat",
-        "ChatMessage.Read.Chat",
-        "ChatMember.Read.Chat",
-        "Chat.Manage.Chat",
-        "TeamsTab.Read.Chat",
-        "TeamsTab.Create.Chat",
-        "TeamsTab.Delete.Chat",
-        "TeamsTab.ReadWrite.Chat",
-        "TeamsAppInstallation.Read.Chat",
-        "OnlineMeeting.ReadBasic.Chat"
-    ];
+
+// Application ID for Graph explorer (official site)
+export const CLIENT_APP_ID = "de8bc8b5-d9f9-48b1-a8ad-b748da725064";
+
+// TODO: Change this URL to `https://gi21devxapi-devtest.azurewebsites.net` once the DevX API `interns/feature/ge-app-mode-proxy-endpoint` branch is merged into `interns/dev`. ADO ticket #39398
+export const DEVX_API_URL = "https://localhost:44399";
 
 export const RSC_NAME_DESCRIPTION = {
     'TeamSettings.Read.Group': "Get this team's settings.",


### PR DESCRIPTION
ADO Board Link: [Task #39003](https://dev.azure.com/microsoftgarage/Intern%20GitHub/_workitems/edit/39003)

## Overview
* We wanted the table of RSC permissions to be dynamically fetched using a DevX API endpoint, rather than hard-coded in a constants file.

### Demo

#### RSC Table for tab in a channel

https://user-images.githubusercontent.com/46834951/127240051-cbb01024-dc22-498e-99d7-438c95cfb5ee.mp4

#### RSC Table for tab in a chat

https://user-images.githubusercontent.com/46834951/127240059-57395538-5ed7-4f5a-a3ce-e3ef63b3e5fe.mp4

### Notes
* The RSC descriptions are still hard-coded. There's another task to fetch the descriptions dynamically: [Task #39370
](https://dev.azure.com/microsoftgarage/Intern%20GitHub/_workitems/edit/39370)
* The DevX API URL is currently hard-coded to localhost, since the DevX API `interns/feature/ge-app-mode-proxy-endpoint` branch has not yet been merged into `interns/dev`. Once that merge is completed, the URL can be changed to our DevX API devtest site: [Task #39398
](https://dev.azure.com/microsoftgarage/Intern%20GitHub/_workitems/edit/39398)

## Testing Instructions
* Pull and run the `interns/feature/ge-app-mode-proxy-endpoint` branch of DevX API
* Pull and run the Teams app
* Disable CORS using a browser extension
* Add the app to a channel or chat tab