### PR TITLE
AB#39458 Interns/gracet9182 display copy without hover

### DIFF
--- a/tabs/src/components/sample/ConnectedResources.jsx
+++ b/tabs/src/components/sample/ConnectedResources.jsx
@@ -14,7 +14,6 @@ export function ProcessTeamsContext() {
     const [resourceList, setResourceList] = useState([]);
     const [title, setTitle] = useState(" ");
     microsoftTeams.getContext(function (context) {
-        console.log("test");
 
         //Check if this is a teams channel
         if (context.channelId && context.channelId.length !== 0) {

--- a/tabs/src/components/sample/ConnectedResources.jsx
+++ b/tabs/src/components/sample/ConnectedResources.jsx
@@ -14,6 +14,7 @@ export function ProcessTeamsContext() {
     const [resourceList, setResourceList] = useState([]);
     const [title, setTitle] = useState(" ");
     microsoftTeams.getContext(function (context) {
+        console.log("test");
 
         //Check if this is a teams channel
         if (context.channelId && context.channelId.length !== 0) {
@@ -35,7 +36,7 @@ export function ProcessTeamsContext() {
             chatId.header = t("Connected Resources.Chat ID") + ": " + context.chatId;
             setResourceList([chatId]);
         }
-        else {
+        else if (title === " ") {
             setTitle("");
             setResourceList([]);
         }
@@ -43,7 +44,7 @@ export function ProcessTeamsContext() {
     return (
         <div className="connected-resource">
             {resourceList.length !== 0 && <ListItem className="title" header={title} />}
-            {resourceList.length !== 0 && <List selectable defaultSelectedIndex={0} items={resourceList} />}
+            {resourceList.length !== 0 && <List defaultSelectedIndex={0} items={resourceList}/>} 
             {resourceList.length === 0 && !title && <Alert danger content={t("Connected Resources.No Connected Resources")} />}
         </div>
     );

--- a/tabs/src/components/sample/MainContent.jsx
+++ b/tabs/src/components/sample/MainContent.jsx
@@ -10,8 +10,8 @@ import { ProcessTeamsContext } from './ConnectedResources.jsx';
 const MainContent = () => {
     const [firstSectionActive, toggleFirstSection] = useState(true);
     const [secondSectionActive, toggleSecondSection] = useState(true);
-    const [thirdSectionActive, toggleThirdSection] = useState(false);
-    const [fourthSectionActive, toggleFourthSection] = useState(false);
+    const [thirdSectionActive, toggleThirdSection] = useState(true);
+    const [fourthSectionActive, toggleFourthSection] = useState(true);
     const { t } = useTranslation();
 
 

--- a/tabs/src/components/sample/MainContent.jsx
+++ b/tabs/src/components/sample/MainContent.jsx
@@ -10,8 +10,8 @@ import { ProcessTeamsContext } from './ConnectedResources.jsx';
 const MainContent = () => {
     const [firstSectionActive, toggleFirstSection] = useState(true);
     const [secondSectionActive, toggleSecondSection] = useState(true);
-    const [thirdSectionActive, toggleThirdSection] = useState(true);
-    const [fourthSectionActive, toggleFourthSection] = useState(true);
+    const [thirdSectionActive, toggleThirdSection] = useState(false);
+    const [fourthSectionActive, toggleFourthSection] = useState(false);
     const { t } = useTranslation();
 
 


### PR DESCRIPTION
# Goal
* Get the copy icon to still show up even if the mouse is not on the query.
# Testing 
* Checkout this branch and add the app to a teams channel
* See that it displays the copy icon without having to hover over the query

https://user-images.githubusercontent.com/47228306/128055470-3123ebd6-7e57-4e6c-9760-46553dcad74e.mp4

