### PR TITLE
AB#39557 remove and update template activity type in manifest

### DIFF
--- a/.fx/manifest.source.json
+++ b/.fx/manifest.source.json
@@ -58,9 +58,9 @@
     "activities": {
         "activityTypes": [
           {
-            "type": "pendingFinanceApprovalRequests",
+            "type": "graphExplorerSampleNotification",
             "description": "Test Activity Type",
-            "templateText": "Internal spending team has a pending finance approval request"
+            "templateText": "Graph Explorer sending a test activity feed notification"
           }
         ]
     }


### PR DESCRIPTION
Work for https://github.com/LokiLabs/microsoft-graph-devx-content/pull/25 to be compatible with the teams app. 