### PR TITLE
AB#39559 Disable and add spinner to Run query button when query is in progress

### DIFF
--- a/tabs/src/components/sample/QueryRunner.jsx
+++ b/tabs/src/components/sample/QueryRunner.jsx
@@ -55,6 +55,7 @@ export function QueryRunner() {
     const [requestComponentIndex, setRequestComponentIndex] = useState(0);
     const [requestHeaders, setRequestHeaders] = useState([]);
     const [responseState, setReponseState] = useState(-1);
+    const [isLoading, setIsLoading] = useState(false);
 
     const requestItems = [
         t("Query Runner.Request body"),
@@ -75,6 +76,7 @@ export function QueryRunner() {
     };
 
     async function callGraph() {
+        setIsLoading(true);
         const queryParameters = query.substring(GRAPH_URL.length + graphVersion.length, query.length);
         const url = RSC_API_URL + graphVersion + queryParameters;
         const cleanedHeaders = {};
@@ -106,6 +108,7 @@ export function QueryRunner() {
             const text = await graphResponse.text();
             setResponseBody(text);
         }
+        setIsLoading(false);
     }
 
     const deleteRow = (header) => {
@@ -199,7 +202,7 @@ export function QueryRunner() {
                             <Input fluid inverted value={query} showSuccessIndicator={false} required onChange={(evt) => setQuery(evt.target.value)} type="text" />
                         </Flex.Item>
                         <Flex.Item size="size.half">
-                            <Button content={t("Query Runner.Run query")} onClick={() => callGraph()} primary />
+                            <Button loading={isLoading} disabled={isLoading} content={t("Query Runner.Run query")} onClick={() => callGraph()} primary />
                         </Flex.Item>
                     </Flex>
                 </Flex.Item>


### PR DESCRIPTION
ADO Board Link: [Task #39559](https://dev.azure.com/microsoftgarage/Intern%20GitHub/_workitems/edit/39559)

## Overview
* We wanted the `Run query` button to be in a "loading state" when a query is in-progress. For example, in the Graph Explorer web app, the `Run query` button is disabled and a spinner is displayed until the query finishes. I replicated the same behaviour in our Teams app.

### Demo

https://user-images.githubusercontent.com/46834951/128264296-1b663d5b-77c1-422f-8cbf-39edb6e1e94a.mp4

### Notes

## Testing Instructions
* Pull and run the Teams app
* Run the query `GET https://graph.microsoft.com/beta`. The `Run query` button should be disabled and a spinner should appear when the query is in-progress. When the query finishes the button should go back to normal. This query should succeed.
* Run the query `GET https://graph.microsoft.com/beta/me`. The `Run query` should have the same behaviour as above. This query should fail.