### PR TITLE
Localization for URLs

### DIFF
--- a/tabs/src/components/sample/DocumentationLinks.jsx
+++ b/tabs/src/components/sample/DocumentationLinks.jsx
@@ -1,16 +1,28 @@
 import React from "react";
-import { GRAPH_EXPLORER_URL, GRAPH_EXPLORER_DOCS_URL, OFFICIAL_RSC_URL } from "./TabConstants";
+import { UNLOCALIZED_GRAPH_EXPLORER_URL, UNLOCALIZED_GRAPH_EXPLORER_DOCS_URL, UNLOCALIZED_OFFICIAL_RSC_URL, localizeUrl } from "./TabConstants";
 import { Button } from '@fluentui/react-northstar';
 import { useTranslation } from 'react-i18next';
 
 const DocumentationLinks = () => {
-    const { t } = useTranslation();
+    const { t, i18n } = useTranslation();
 
     return (
         <div className="documentation-links">
-            <Button content={t("Documentation Links.Go to Graph Explorer")} onClick={() => window.open(GRAPH_EXPLORER_URL)} primary />
-            <Button content={t("Documentation Links.Graph Explorer Documentation")} onClick={() => window.open(GRAPH_EXPLORER_DOCS_URL)} primary />
-            <Button content={t("Documentation Links.Resource-Specific Consent")} onClick={() => window.open(OFFICIAL_RSC_URL)} primary />
+            <Button 
+                content={t("Documentation Links.Go to Graph Explorer")} 
+                onClick={() => window.open(localizeUrl(UNLOCALIZED_GRAPH_EXPLORER_URL, i18n))} 
+                primary 
+            />
+            <Button 
+                content={t("Documentation Links.Graph Explorer Documentation")} 
+                onClick={() => window.open(localizeUrl(UNLOCALIZED_GRAPH_EXPLORER_DOCS_URL, i18n))} 
+                primary 
+            />
+            <Button 
+                content={t("Documentation Links.Resource-Specific Consent")} 
+                onClick={() => window.open(localizeUrl(UNLOCALIZED_OFFICIAL_RSC_URL, i18n))} 
+                primary 
+            />
         </div>
     );
 };

--- a/tabs/src/components/sample/TabConstants.jsx
+++ b/tabs/src/components/sample/TabConstants.jsx
@@ -1,9 +1,13 @@
-export const GRAPH_EXPLORER_URL = "https://developer.microsoft.com/en-us/graph/graph-explorer";
-export const GRAPH_EXPLORER_DOCS_URL = "https://docs.microsoft.com/en-us/graph/api/resources/teams-api-overview?view=graph-rest-1.0";
+export const UNLOCALIZED_GRAPH_EXPLORER_URL = "https://developer.microsoft.com/{LOCALE}/graph/graph-explorer";
+export const UNLOCALIZED_GRAPH_EXPLORER_DOCS_URL = "https://docs.microsoft.com/{LOCALE}/graph/api/resources/teams-api-overview?view=graph-rest-1.0";
+export const UNLOCALIZED_OFFICIAL_RSC_URL = "https://docs.microsoft.com/{LOCALE}/microsoftteams/platform/graph-api/rsc/resource-specific-consent#:~:text=Resource-specific%20consent%20%28RSC%29%20is%20a%20Microsoft%20Teams%20and,manage%20specific%20resources%E2%80%94either%20teams%20or%20chats%E2%80%94within%20an%20organization.";
+export const UNLOCALIZED_MS_GRAPH_DOCS = "https://docs.microsoft.com/{LOCALE}/";
 export const RSC_DOCUMENTATION_URL = "https://raw.githubusercontent.com/MicrosoftDocs/msteams-docs/master/msteams-platform/graph-api/rsc/resource-specific-consent.md";
-export const OFFICIAL_RSC_URL = "https://docs.microsoft.com/en-us/microsoftteams/platform/graph-api/rsc/resource-specific-consent#:~:text=Resource-specific%20consent%20%28RSC%29%20is%20a%20Microsoft%20Teams%20and,manage%20specific%20resources%E2%80%94either%20teams%20or%20chats%E2%80%94within%20an%20organization.";
 export const README_HEADER = "---";
-export const MS_GRAPH_DOCS = "(https://docs.microsoft.com/en-us/";
+
+export function localizeUrl(url, i18n) {
+    return url.replace("{LOCALE}", i18n.language);
+}
 
 // Application ID for Graph explorer (official site)
 export const CLIENT_APP_ID = "de8bc8b5-d9f9-48b1-a8ad-b748da725064";


### PR DESCRIPTION
**What?**
Localization for clickable URLs in our app!
For example, if someone on Chinese locale wanted to click a docs URL at the bottom of our page, before this PR it would send them to `en-US`. After this PR, it should send them to `zh-CN`.

**To Test:**
- Launch the app
- Go to Documentation Links
- Click a link and observe the locale matches the locale your app was in
- Try with a different locale to observe the clickable links will change as well (for ex, try `zh-CN` as opposed to `en-US`)

https://user-images.githubusercontent.com/49354780/128514078-76687d2a-04bc-4dfe-89cd-ed0c5e799a79.mp4


**Ticket:**
[AD#39435](https://dev.azure.com/microsoftgarage/Intern%20GitHub/_sprints/taskboard/GI21%20-%20Graph%20Explorer/Intern%20GitHub/Y21-S/09?workitem=39435)