### PR TITLE
FIX: Dark Theme Not Covering Full Page

### DIFF
--- a/tabs/src/components/App.jsx
+++ b/tabs/src/components/App.jsx
@@ -23,7 +23,7 @@ export default function App() {
     changeLanguage(i18n, isTeams.context.locale);
   }
   return (
-    <Provider theme={theme || teamsTheme} styles={{ backgroundColor: "#eeeeee" }}>
+    <Provider theme={theme || teamsTheme} styles={{ backgroundColor: "#eeeeee", minHeight: "50vh" }}>
       <Router>
         <Route exact path="/">
           <Redirect to="/tab" />


### PR DESCRIPTION
This PR ensures that the dark theme stretches to the bottom of the page by setting a minimum viewport height with the CSS of the Provider.

**Before:**

![image](https://user-images.githubusercontent.com/49354780/128530164-37660b48-74fe-4b9f-a419-8ff7f1b40d08.png)

**After:**

![image](https://user-images.githubusercontent.com/49354780/128530267-94ad0811-4f37-4bf7-815c-a51da1d5e11e.png)

This change applies to all themes, including High Contrast :D 

