### PR TITLE
AB#39586 Changed documentation buttons to hyperlinks

### DIFF
--- a/tabs/src/components/app/views/DocumentationLinks.jsx
+++ b/tabs/src/components/app/views/DocumentationLinks.jsx
@@ -1,28 +1,46 @@
 import React from "react";
 import { UNLOCALIZED_GRAPH_EXPLORER_URL, UNLOCALIZED_GRAPH_EXPLORER_DOCS_URL, UNLOCALIZED_OFFICIAL_RSC_URL, localizeUrl } from "../../TabConstants";
-import { Button } from '@fluentui/react-northstar';
 import { useTranslation } from 'react-i18next';
+import { useTeamsFx } from "../../utils/useTeamsFx";
 
 export const DocumentationLinks = () => {
     const { t, i18n } = useTranslation();
+    const { themeString } = useTeamsFx();
+
+    let linkColor = "#6264A7";
+    switch(themeString) {
+        case "default":
+            linkColor = "#6264A7";
+            break;
+        case "dark":
+            linkColor = "#A6A7DC";
+            break;
+        case "contrast":
+            linkColor = "#ffff01";
+            break;
+        default:
+            linkColor = "#6264A7";
+    }
 
     return (
         <div className="documentation-links">
-            <Button
-                content={t("Documentation Links.Go to Graph Explorer")}
-                onClick={() => window.open(localizeUrl(UNLOCALIZED_GRAPH_EXPLORER_URL, i18n))}
-                primary
-            />
-            <Button
-                content={t("Documentation Links.Graph Explorer Documentation")}
-                onClick={() => window.open(localizeUrl(UNLOCALIZED_GRAPH_EXPLORER_DOCS_URL, i18n))}
-                primary
-            />
-            <Button
-                content={t("Documentation Links.Resource-Specific Consent")}
-                onClick={() => window.open(localizeUrl(UNLOCALIZED_OFFICIAL_RSC_URL, i18n))}
-                primary
-            />
+            <ul>
+                <li>
+                    <a className="documentation-link" href={localizeUrl(UNLOCALIZED_GRAPH_EXPLORER_URL, i18n)} target="_blank" rel="noreferrer noopener" style={{ color: linkColor }}>
+                        {t("Documentation Links.Go to Graph Explorer")}
+                    </a>
+                </li>
+                <li>
+                    <a className="documentation-link" href={localizeUrl(UNLOCALIZED_GRAPH_EXPLORER_DOCS_URL, i18n)} target="_blank" rel="noreferrer noopener" style={{ color: linkColor }}>
+                        {t("Documentation Links.Graph Explorer Documentation")}
+                    </a>
+                </li>
+                <li>
+                    <a className="documentation-link" href={localizeUrl(UNLOCALIZED_OFFICIAL_RSC_URL, i18n)} target="_blank" rel="noreferrer noopener" style={{ color: linkColor }}>
+                        {t("Documentation Links.Resource-Specific Consent")}
+                    </a>
+                </li>
+            </ul>
         </div>
     );
 };

--- a/tabs/src/components/app/views/DocumentationLinks.jsx
+++ b/tabs/src/components/app/views/DocumentationLinks.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { UNLOCALIZED_GRAPH_EXPLORER_URL, UNLOCALIZED_GRAPH_EXPLORER_DOCS_URL, UNLOCALIZED_OFFICIAL_RSC_URL, localizeUrl } from "../../TabConstants";
 import { useTranslation } from 'react-i18next';
 import { useTeamsFx } from "../../utils/useTeamsFx";
+import { MediumFontLink } from "./MediumFontLink";
 
 export const DocumentationLinks = () => {
     const { t, i18n } = useTranslation();
@@ -23,24 +24,16 @@ export const DocumentationLinks = () => {
     }
 
     return (
-        <div className="documentation-links">
-            <ul>
-                <li>
-                    <a className="documentation-link" href={localizeUrl(UNLOCALIZED_GRAPH_EXPLORER_URL, i18n)} target="_blank" rel="noreferrer noopener" style={{ color: linkColor }}>
-                        {t("Documentation Links.Go to Graph Explorer")}
-                    </a>
-                </li>
-                <li>
-                    <a className="documentation-link" href={localizeUrl(UNLOCALIZED_GRAPH_EXPLORER_DOCS_URL, i18n)} target="_blank" rel="noreferrer noopener" style={{ color: linkColor }}>
-                        {t("Documentation Links.Graph Explorer Documentation")}
-                    </a>
-                </li>
-                <li>
-                    <a className="documentation-link" href={localizeUrl(UNLOCALIZED_OFFICIAL_RSC_URL, i18n)} target="_blank" rel="noreferrer noopener" style={{ color: linkColor }}>
-                        {t("Documentation Links.Resource-Specific Consent")}
-                    </a>
-                </li>
-            </ul>
-        </div>
+        <ul>
+            <li>
+                <MediumFontLink URL={localizeUrl(UNLOCALIZED_GRAPH_EXPLORER_URL, i18n)} content={t("Documentation Links.Go to Graph Explorer")} linkColor={linkColor} />
+            </li>
+            <li>
+                <MediumFontLink URL={localizeUrl(UNLOCALIZED_GRAPH_EXPLORER_DOCS_URL, i18n)} content={t("Documentation Links.Graph Explorer Documentation")} linkColor={linkColor} />
+            </li>
+            <li>
+                <MediumFontLink URL={localizeUrl(UNLOCALIZED_OFFICIAL_RSC_URL, i18n)} content={t("Documentation Links.Resource-Specific Consent")} linkColor={linkColor} />
+            </li>
+        </ul>
     );
 };

--- a/tabs/src/components/app/views/MediumFontLink.jsx
+++ b/tabs/src/components/app/views/MediumFontLink.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+import PropTypes from 'prop-types';
+
+MediumFontLink.propTypes = {
+    URL: PropTypes.string,
+    content: PropTypes.string,
+    linkColor: PropTypes.string,
+};
+
+export function MediumFontLink(props) {
+    const URL = props.URL;
+    const content = props.content;
+    const linkColor = props.linkColor;
+
+    return (
+        <a className="medium-link" href={URL} target="_blank" rel="noreferrer noopener" style={{ color: linkColor }}>
+            {content}
+        </a>
+    );
+}

--- a/tabs/src/components/style/DocumentationLinks.css
+++ b/tabs/src/components/style/DocumentationLinks.css
@@ -1,14 +1,3 @@
-.documentation-links {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-}
-
-@media (max-width: 900px) {
-    .documentation-links {
-        flex-direction: column;
-    }
-    .documentation-links button {
-        margin-bottom: 2%;
-    }
+.documentation-link {
+    font-size: medium
 }

--- a/tabs/src/components/style/MediumFontLink.css
+++ b/tabs/src/components/style/MediumFontLink.css
@@ -1,3 +1,3 @@
-.documentation-link {
+.medium-link {
     font-size: medium
 }

--- a/tabs/src/index.css
+++ b/tabs/src/index.css
@@ -4,7 +4,7 @@
 @import url("components/style/TableOfContents.css");
 @import url("components/style/QueryRunner.css");
 @import url("components/style/Tab.css");
-@import url("components/style/DocumentationLinks.css");
+@import url("components/style/MediumFontLink.css");
 @import url("components/style/SampleQueries.css");
 * {
   box-sizing: border-box;


### PR DESCRIPTION
ADO Board Link: [Task #39586](https://dev.azure.com/microsoftgarage/Intern%20GitHub/_workitems/edit/39586)

## Overview
* Based on sponsor feedback, we wanted to change the documentation buttons to hyperlinks.
* We wanted the hyperlinks to change color depending on theme (default, dark, etc.).

### Demo

https://user-images.githubusercontent.com/46834951/128905024-e08b5e45-c3ad-42f9-b246-0aac3a50675a.mp4

### Notes

## Testing Instructions
* Pull and run the Teams app.
* Expand the `Documentation Links` section and click the hyperlinks to verify that they take you to the correct pages.
* Change the theme of Teams to `Dark` and refresh the app.
* Expand the `Documentation Links` section and click the hyperlinks to verify that they take you to the correct pages.
* Change the theme of Teams to `High contrast` and refresh the app.
* Expand the `Documentation Links` section and click the hyperlinks to verify that they take you to the correct pages.
