### PR TITLE
Expanding Query Input

### DIFF
--- a/tabs/src/components/app/views/runner/QueryInput.jsx
+++ b/tabs/src/components/app/views/runner/QueryInput.jsx
@@ -1,7 +1,8 @@
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { requestTypes, graphVersions, GRAPH_URL } from '../../../TabConstants';
-import { Button, Input, Flex, Dropdown } from '@fluentui/react-northstar';
+import { Button, Flex, Dropdown } from '@fluentui/react-northstar';
+import { TextField } from 'office-ui-fabric-react';
 import { useTranslation } from "react-i18next";
 import PropTypes from 'prop-types';
 
@@ -28,9 +29,25 @@ export function QueryInput(props) {
     const callGraph = props.callGraph;
     const isLoading = props.isLoading;
     const isConnectedToResource = props.isConnectedToResource;
+    const [element, setElement] = useState(null);
 
     // Translations
     const { t } = useTranslation();
+
+    function isInputOverflowing(element, input) {
+
+        function getTextWidth(text) {
+            const canvas = document.createElement('canvas');
+            const context = canvas.getContext('2d');
+            if (context === null) {
+                return 0;
+            }
+            context.font = getComputedStyle(document.body).font;
+            return context.measureText(text).width + 5;
+        }
+
+        return !!element && getTextWidth(input) > element.scrollWidth;
+    }
 
     useEffect(() => {
         setQuery(GRAPH_URL + graphVersion + query.substring(GRAPH_URL.length + graphVersion.length, query.length));
@@ -63,14 +80,19 @@ export function QueryInput(props) {
             <Flex.Item grow>
                 <Flex gap="gap.small">
                     <Flex.Item grow>
-                        <Input
-                            fluid
-                            inverted
-                            value={query}
-                            showSuccessIndicator={false}
-                            required
-                            onChange={(evt) => setQuery(evt.target.value)}
-                            type="text" />
+                        <div ref={(el) => { setElement(el); }}>
+                            <TextField
+                                fluid
+                                inverted
+                                value={query}
+                                showSuccessIndicator={false}
+                                required={false}
+                                onChange={(evt) => setQuery(evt.target.value)}
+                                multiline={isInputOverflowing(element,query)}
+                                autoAdjustHeight
+                                resizable={false}
+                                type="text" />
+                        </div>
                     </Flex.Item>
                     <Flex.Item size="size.half">
                         <Button


### PR DESCRIPTION
Just like in the Main GE :3 Query runner should expand/contract, and set to single-line if not overflowing.

![image](https://user-images.githubusercontent.com/49354780/128919673-45eed12a-db62-452b-9bbb-e7eb90970708.png)

![image](https://user-images.githubusercontent.com/49354780/128919783-3e5b359f-84df-4e20-abf6-6ec5f49e83bb.png)


[AD#39628](https://dev.azure.com/microsoftgarage/Intern%20GitHub/_sprints/taskboard/GI21%20-%20Graph%20Explorer/Intern%20GitHub/Y21-S/10?workitem=39628)